### PR TITLE
Fix Race Condition when webchannel has not fully authenticated

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -1,4 +1,3 @@
-
 package cmd
 
 import (
@@ -6,17 +5,18 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
 	"github.com/spf13/cobra"
+
 	//"github.com/spf13/viper"
 
 	"github.com/soarinferret/mcc/internal/meshcentral"
 )
 
-
 var sshCmd = &cobra.Command{
-	Use:     "ssh [user][@target]",
-	Short:   "Shortcut to ssh into a node",
-	Long:    `Opens SSH connection with the OpenSSH Client to a node via the local proxy`,
+	Use:   "ssh [user][@target]",
+	Short: "Shortcut to ssh into a node",
+	Long:  `Opens SSH connection with the OpenSSH Client to a node via the local proxy`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		user := "root"
@@ -73,12 +73,12 @@ var sshCmd = &cobra.Command{
 
 		// start ssh client
 		sshPort := meshcentral.GetLocalPort()
-		fmt.Printf("SSH into %s:%d via 127.0.0.1%d\n", target, remoteport, sshPort)
-		sshCmd := exec.Command(	"ssh", "-o", "ServerAliveInterval=60",
-								"-o", "ServerAliveCountMax=3",
-							 	"-o", "StrictHostKeyChecking=no",
-								"-o", "UserKnownHostsFile=/dev/null",
-							 	fmt.Sprintf("-p%d", sshPort), fmt.Sprintf("%s@127.0.0.1", user),
+		fmt.Printf("SSH into %s:%d via 127.0.0.1:%d\n", target, remoteport, sshPort)
+		sshCmd := exec.Command("ssh", "-o", "ServerAliveInterval=60",
+			"-o", "ServerAliveCountMax=3",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "UserKnownHostsFile=/dev/null",
+			fmt.Sprintf("-p%d", sshPort), fmt.Sprintf("%s@127.0.0.1", user),
 		)
 		sshCmd.Stdout = os.Stdout
 		sshCmd.Stderr = os.Stderr
@@ -88,9 +88,9 @@ var sshCmd = &cobra.Command{
 			fmt.Printf("Unable to start SSH client: %v\n", err)
 		}
 
-
 	},
 }
+
 func init() {
 	rootCmd.AddCommand(sshCmd)
 

--- a/internal/meshcentral/auth.go
+++ b/internal/meshcentral/auth.go
@@ -216,16 +216,3 @@ func handleServerAuthCommand(command map[string]interface{}) {
 
 	settings.WebSocket.WriteMessage(websocket.TextMessage, []byte(auth))
 }
-
-// another hacky thing
-func sendAuthCookie() {
-	settings.WebSocket.WriteMessage(websocket.TextMessage, []byte(`{"action":"authcookie"}`))
-
-	// when settings.ACookie is set, return
-	for {
-		if settings.ACookie != "" {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}

--- a/internal/meshcentral/config.go
+++ b/internal/meshcentral/config.go
@@ -2,50 +2,50 @@ package meshcentral
 
 import (
 	"time"
+
 	"github.com/gorilla/websocket"
 )
 
-
 type Device struct {
-	Id     string
-	Name   string
-	OS     string
-	IP     string
-	Icon   int
-	Conn   int
-	Pwr    int
+	Id   string
+	Name string
+	OS   string
+	IP   string
+	Icon int
+	Conn int
+	Pwr  int
 }
 
 type Settings struct {
-	ServerURL       string
-	Username        string
-	Password        string
-	Token           string
-	EmailToken      bool
-	SMSToken        bool
-	AuthCookie      string
-	ServerID        string
-	LoginKey        string
-	LocalPort       int
-	RemotePort      int
-	RemoteTarget    string
-	RemoteNodeID    string
-	WebSocket       *websocket.Conn
-	WebChannel      *websocket.Conn
-	ACookie         string
-	RCookie         string
-	RenewCookieTimer *time.Timer
+	ServerURL             string
+	Username              string
+	Password              string
+	Token                 string
+	EmailToken            bool
+	SMSToken              bool
+	AuthCookie            string
+	ServerID              string
+	LoginKey              string
+	LocalPort             int
+	RemotePort            int
+	RemoteTarget          string
+	RemoteNodeID          string
+	WebSocket             *websocket.Conn
+	WebChannel            chan struct{}
+	ACookie               string
+	RCookie               string
+	RenewCookieTimer      *time.Timer
 	ServerAuthClientNonce string
-	MeshServerTlsHash string
-	ServerHttpsHash string
-	Devices		   []Device
-	DeviceQueryState int
-	debug		   bool
+	MeshServerTlsHash     string
+	ServerHttpsHash       string
+	Devices               []Device
+	DeviceQueryState      int
+	debug                 bool
 }
 
 var settings Settings
 
-func ApplySettings(remoteNodeId string, remotePort int, localPort int, remoteTarget string, debug bool){
+func ApplySettings(remoteNodeId string, remotePort int, localPort int, remoteTarget string, debug bool) {
 	//settings.ServerURL = serverUrl
 	//settings.Username = username
 	//settings.Password = password

--- a/internal/meshcentral/router.go
+++ b/internal/meshcentral/router.go
@@ -2,14 +2,14 @@ package meshcentral
 
 import (
 	"crypto/tls"
-	"io"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -27,6 +27,9 @@ func StartRouter(ready chan struct{}) {
 	}
 	settings.LocalPort = listener.Addr().(*net.TCPAddr).Port
 	defer listener.Close()
+
+	// wait for server to be authenticated
+	<-settings.WebChannel
 
 	close(ready)
 	fmt.Printf("Redirecting local port %d to remote port %d.\n", listener.Addr().(*net.TCPAddr).Port, settings.RemotePort)


### PR DESCRIPTION
As identified by #2 , specifying a nodeid was causing a race condition that the server had not fully authenticated before we trying to send traffic over the tunnel.

I re-purposed the `settings.Webchannel` to be used as a channel instead of a redundant websocket connection, and use that to determine when we are ready to move on. This also allowed me to remove some "hacky" code I was using to get around this problem before in the shell feature.